### PR TITLE
Running container in elevated mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,11 +63,12 @@ services:
   speedtest:
     tty: true
     stdin_open: true
+    privileged: true
     expose:
       - 9798
     ports:
       - 9798:9798
-    image: miguelndecarvalho/speedtest-exporter
+    image: miguelndecarvalho/speedtest-exporter:v3.2.2
     restart: always
     networks:
       - back-tier


### PR DESCRIPTION
To avoid this initialisation failure on a raspberry PI 4 8gb model (`Linux raspberrypi 5.10.17-v7l+ #1421 SMP Thu May 27 14:00:13 BST 2021 armv7l GNU/Linux`).

```
speedtest_1   | Current thread 0xb6fa0390 (most recent call first):
speedtest_1   | <no Python frame>
speedtest_1   | Fatal Python error: init_interp_main: can't initialize time
speedtest_1   | Python runtime state: core initialized
speedtest_1   | PermissionError: [Errno 1] Operation not permitted
```

Also fixed the speedtest container version, in case the maintainer does some weird breaking change in the future.